### PR TITLE
Revert dependency changes for classifier-pipeline-resnet and detector

### DIFF
--- a/classifier-pipeline-resnet/classifier-pipeline-resnet-ps/1/models/model/requirements.txt
+++ b/classifier-pipeline-resnet/classifier-pipeline-resnet-ps/1/models/model/requirements.txt
@@ -1,4 +1,5 @@
-clarifai>=12.3
+clarifai==12.1.4
+clarifai-protocol>=0.0.23,<0.0.36
 Pillow==12.0.0
 PyYAML==6.0.3
 mmcv==2.2.0

--- a/classifier-pipeline-resnet/classifier-pipeline-resnet-ps/requirements.txt
+++ b/classifier-pipeline-resnet/classifier-pipeline-resnet-ps/requirements.txt
@@ -1,5 +1,6 @@
-clarifai>=12.3
-clarifai-grpc>=12.0.2
+clarifai==12.1.4
+clarifai-protocol>=0.0.23,<0.0.36
+clarifai-grpc==12.0.2
 boto3==1.42.4
 mmcv==2.2.0
 mmengine==0.10.7

--- a/detector-pipeline-yolof/detector-pipeline-yolof-ps/1/models/model/requirements.txt
+++ b/detector-pipeline-yolof/detector-pipeline-yolof-ps/1/models/model/requirements.txt
@@ -1,3 +1,4 @@
-clarifai>=12.3
+clarifai==12.1.4
+clarifai-protocol>=0.0.23,<0.0.36
 Pillow==12.0.0
 PyYAML==6.0.3

--- a/detector-pipeline-yolof/detector-pipeline-yolof-ps/requirements.txt
+++ b/detector-pipeline-yolof/detector-pipeline-yolof-ps/requirements.txt
@@ -1,5 +1,6 @@
-clarifai>=12.3
-clarifai-grpc>=12.0.2
+clarifai==12.1.4
+clarifai-protocol>=0.0.23,<0.0.36
+clarifai-grpc==12.0.2
 boto3==1.42.4
 scipy==1.15.3
 yapf==0.40.1


### PR DESCRIPTION
Reverts the dependency updates from 050fc56 for these two pipelines, restoring pinned versions (clarifai==12.1.4, clarifai-protocol, clarifai-grpc==12.0.2). Since the pipeline step version ID is fixed to the older clarifai version.