### PR TITLE
 Improve clarifai pipeline init quick-start guidance   

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This repository contains pipeline templates for training machine learning models
 
 ```bash
 pip install clarifai
+clarifai login   # interactive: paste your Personal Access Token when prompted
+```
+
+Alternatively, set the PAT non-interactively:
+
+```bash
 export CLARIFAI_PAT=<your_personal_access_token>
 ```
 
@@ -21,14 +27,50 @@ clarifai pipelinetemplate ls
 
 ```bash
 clarifai pipeline init --template=classifier-pipeline-resnet-quick-start
+```
+
+This creates a new folder named after the template. **`cd` into that folder before
+running any of the subsequent `clarifai pipeline ...` commands** — they read the
+local `config.yaml` / `config-lock.yaml`:
+
+```bash
 cd classifier-pipeline-resnet-quick-start
+```
+
+Optional — override defaults at init time (different user/app from your `clarifai login`,
+a custom pipeline ID, or a model parameter default):
+
+```bash
+clarifai pipeline init --template=classifier-pipeline-resnet-quick-start \
+  --user_id MY_CUSTOM_USER_ID --app_id MY_CUSTOM_APP_ID \
+  --set id=MY_CUSTOM_PIPELINE_ID --set num_epochs=20
 ```
 
 ### Step 4: Upload and Run the Pipeline
 
+Make sure you are inside the generated pipeline folder (e.g. `classifier-pipeline-resnet-quick-start/`)
+from Step 3, then upload:
+
 ```bash
 clarifai pipeline upload
-clarifai pipeline run --nodepool_id=<your_nodepool_id> --compute_cluster_id=<your_compute_cluster_id>
+```
+
+Then run the pipeline using **one** of the two compute options:
+
+```bash
+# (a) Simplest — auto-create or reuse compute from an instance type
+clarifai pipeline run --instance=g6e.xlarge
+
+# (b) Use your existing nodepool + compute cluster (both flags required)
+clarifai pipeline run \
+  --nodepool_id=<your_existing_nodepool_id> \
+  --compute_cluster_id=<your_existing_compute_cluster_id>
+```
+
+To override pipeline parameters at run time, repeat `--set key=value`:
+
+```bash
+clarifai pipeline run --instance=g6e.xlarge --set num_epochs=20 --set batch_size=32
 ```
 
 ### Step 5: Monitor Your Pipeline
@@ -45,9 +87,10 @@ Quick-start pipelines come with **default public datasets** pre-configured, so y
 |----------|-------------|
 | `classifier-pipeline-resnet-quick-start` | Image classification with ResNet and sample dataset |
 | `detector-pipeline-yolof-quick-start` | Object detection with YOLOF and sample dataset |
+| `detector-pipeline-eval-yolof-quick-start` | Evaluation pipeline for a pretrained YOLOF detector — runs inference on a dataset and reports COCO detection metrics (no training) |
 | `lora-pipeline-unsloth-quick-start` | LLM LoRA fine-tuning with Unsloth and sample dataset |
 
-### Standard Pipelines
+### Other Pipeline Examples
 
 These are diverse pipelines (some of them may require additional setting up, e.g. a Clarifai dataset as a prerequisite).
 


### PR DESCRIPTION
 Updates the quick-start README to match the working flow: adds `clarifai login`                                                          
  after install, makes the `cd` into the generated pipeline folder explicit before
  `upload` / `run`, shows both `--instance=` and `--nodepool_id` + `--compute_cluster_id`                                                  
  run options with a repeated `--set` example, and adds the missing                                                                        
  `detector-pipeline-eval-yolof-quick-start` to the quick-start templates list. 