### PR TITLE
Fix default model_id value for lora pipeline

### DIFF
--- a/lora-pipeline-unsloth-quick-start/config.yaml
+++ b/lora-pipeline-unsloth-quick-start/config.yaml
@@ -19,7 +19,7 @@ pipeline:
             - name: app_id
               value: "<YOUR_APP_ID>"
             - name: model_id
-              value: "<YOUR_MODEL_ID>"
+              value: "test_model"
             - name: base_model_name
               value: "unsloth/Qwen3-0.6B"
             - name: dataset_name


### PR DESCRIPTION
Changed the default <YOUR_MODEL_ID> to "test_model" for lora pipeline template.