### PR TITLE
Add llmcompressor quick start pipeline

### DIFF
--- a/llmcompressor-pipeline-quick-start/.gitignore
+++ b/llmcompressor-pipeline-quick-start/.gitignore
@@ -1,0 +1,6 @@
+cache/
+outputs/
+logs/
+llm-compressor*/
+*.pyc
+__pycache__/

--- a/llmcompressor-pipeline-quick-start/README.md
+++ b/llmcompressor-pipeline-quick-start/README.md
@@ -1,0 +1,110 @@
+# LLM Compressor Quantization Pipeline
+
+Clarifai pipeline that quantizes a HuggingFace causal LM with vLLM's
+[llm-compressor](https://github.com/vllm-project/llm-compressor) and
+uploads the resulting compressed-tensors checkpoint as a Clarifai
+artifact you can later download.
+
+One `pipeline_step.py`, given a target model + a few params, will:
+
+1. Download the source model from HuggingFace.
+2. Quantize with the chosen scheme + pipeline (datafree / basic / sequential).
+3. Smoke-test the produced checkpoint with a load + chat-template generate.
+4. Upload the checkpoint zip to Clarifai as a versioned `Artifact`.
+
+The container bakes a pinned `llm-compressor` commit and a tested set of
+`compressed-tensors` / `transformers` / `huggingface-hub` / `torchvision`
+versions, so the run is reproducible.
+
+---
+
+## Defaults and the MoE NVFP4 variant
+
+The defaults run a fast int4 weight-only sanity (Qwen2.5-0.5B, W4A16,
+datafree, 1 GPU). For the W4A4 NVFP4 reference run on a small MoE model
+(Granite-4-h-tiny) — pairing with NVFP4 means picking a scheme that needs
+activation calibration, so `pipeline` must be empty (auto-infer →
+sequential):
+
+| Param | Fast sanity (default) | MoE NVFP4 reference |
+|---|---|---|
+| `src` | `Qwen/Qwen2.5-0.5B-Instruct` | `ibm-granite/granite-4.0-h-tiny` |
+| `scheme` | `W4A16` | `NVFP4` |
+| `pipeline` | `datafree` | `""` (auto-infer → sequential) |
+| `num_gpus` | `1` | `1` |
+| `user_id` / `app_id` / `artifact_id` | your Clarifai user/app / `quantized-checkpoint` | same |
+
+Full param descriptions live in `pipeline_step.py --help`.
+
+---
+
+## Upload and run the pipeline
+
+From inside this folder (`llmcompressor_pipeline/`), upload once:
+
+```bash
+clarifai pipeline upload
+```
+
+Then run with one of the two compute options:
+
+```bash
+# (a) Simplest — auto-create or reuse compute from an instance type
+clarifai pipeline run --instance=g6e.xlarge
+
+# (b) Use your existing nodepool + compute cluster (both flags required)
+clarifai pipeline run \
+    --nodepool_id=<your_existing_nodepool_id> \
+    --compute_cluster_id=<your_existing_compute_cluster_id>
+```
+
+Override params at runtime by repeating `--set key=value`:
+
+```bash
+# Reproduce the MoE NVFP4 reference run
+clarifai pipeline run --instance=g6e.xlarge \
+    --set src=ibm-granite/granite-4.0-h-tiny \
+    --set scheme=NVFP4 \
+    --set pipeline=
+```
+
+### Monitor
+
+Visit `https://clarifai.com/<YOUR_USER_ID>/<YOUR_APP_ID>` and check the
+**Pipelines** tab to follow run progress. The uploaded checkpoint lands
+under the **Artifacts** tab when the run finishes.
+
+---
+
+## Download the artifact and verify it locally
+
+`test_download_and_sanity.py` (in this folder) downloads the produced
+artifact via the Clarifai SDK, unzips it, then runs an HF transformers
+load + chat-template generate to verify the checkpoint is
+downstream-deployable. Run it inside the same container image used by
+the pipeline so the torch / transformers / compressed-tensors versions
+match what the artifact was saved with:
+
+```bash
+# One-time build of the container image
+docker build -t llmcompressor-pipeline:local quantize-step/
+
+# Download + verify the latest version of the artifact
+docker run --rm --gpus all --ipc=host --network=host --shm-size=32g --ulimit memlock=-1 \
+    -v "$PWD/test_download_and_sanity.py:/tmp/test_download_and_sanity.py:ro" \
+    -e CLARIFAI_PAT="<your_pat>" \
+    -e CLARIFAI_API_BASE="https://api.clarifai.com" \
+    llmcompressor-pipeline:local \
+    python /tmp/test_download_and_sanity.py \
+        --user_id <YOUR_USER_ID> \
+        --app_id <YOUR_APP_ID> \
+        --artifact_id quantized-checkpoint \
+        --workdir /workspace/artifact-roundtrip
+```
+
+Pass `--version_id <id>` to download a specific version; omit it and the
+script picks the most recent version automatically. A coherent
+`def reverse_list(lst): return lst[::-1]` answer at the end of the
+script output means the artifact contains everything needed for
+inference (`model.safetensors`, `config.json`, tokenizer files,
+`recipe.yaml`).

--- a/llmcompressor-pipeline-quick-start/config.yaml
+++ b/llmcompressor-pipeline-quick-start/config.yaml
@@ -1,0 +1,57 @@
+pipeline:
+  id: "<YOUR_PIPELINE_ID>"
+  user_id: "<YOUR_USER_ID>"
+  app_id: "<YOUR_APP_ID>"
+  step_directories:
+    - quantize-step
+  orchestration_spec:
+    argo_orchestration_spec: |
+      apiVersion: argoproj.io/v1alpha1
+      kind: Workflow
+      metadata:
+        generateName: <YOUR_PIPELINE_ID>
+      spec:
+        entrypoint: sequence
+        arguments:
+          parameters:
+            - name: src
+              value: "Qwen/Qwen2.5-0.5B-Instruct"
+            - name: scheme
+              value: "W4A16"
+            - name: pipeline
+              value: "datafree"
+            - name: num_gpus
+              value: "1"
+            - name: out
+              value: "/workspace/outputs/quantized_model"
+            - name: user_id
+              value: ""
+            - name: app_id
+              value: ""
+            - name: artifact_id
+              value: "quantized-checkpoint"
+        templates:
+        - name: sequence
+          steps:
+          - - name: quantize-step-name
+              templateRef:
+                name: users/<YOUR_USER_ID>/apps/<YOUR_APP_ID>/pipeline_steps/quantize-step
+                template: users/<YOUR_USER_ID>/apps/<YOUR_APP_ID>/pipeline_steps/quantize-step
+              arguments:
+                parameters:
+                  - name: src
+                    value: "{{workflow.parameters.src}}"
+                  - name: scheme
+                    value: "{{workflow.parameters.scheme}}"
+                  - name: pipeline
+                    value: "{{workflow.parameters.pipeline}}"
+                  - name: num_gpus
+                    value: "{{workflow.parameters.num_gpus}}"
+                  - name: out
+                    value: "{{workflow.parameters.out}}"
+                  - name: user_id
+                    value: "{{workflow.parameters.user_id}}"
+                  - name: app_id
+                    value: "{{workflow.parameters.app_id}}"
+                  - name: artifact_id
+                    value: "{{workflow.parameters.artifact_id}}"

--- a/llmcompressor-pipeline-quick-start/quantize-step/1/pipeline_step.py
+++ b/llmcompressor-pipeline-quick-start/quantize-step/1/pipeline_step.py
@@ -54,11 +54,22 @@ def upload_artifact(out: str, artifact_id: str, user_id: str, app_id: str) -> No
     """Zip the quantized checkpoint dir and upload as a Clarifai artifact version."""
     from clarifai.client.artifact import Artifact
     from clarifai.client.artifact_version import ArtifactVersion
+    from clarifai.client.user import User
 
     archive_base = str(Path(out).parent / Path(out).name)
     archive = shutil.make_archive(archive_base, "zip", root_dir=out)
     print(f"\n>>> upload: {archive} -> user={user_id} app={app_id} artifact_id={artifact_id}",
           flush=True)
+
+    user = User(user_id=user_id)
+    try:
+        user.app(app_id=app_id)
+    except Exception as e:
+        if "does not exist" in str(e).lower():
+            print(f">>> app '{app_id}' not found, creating it", flush=True)
+            user.create_app(app_id=app_id)
+        else:
+            raise
 
     existing = list(Artifact().list(user_id=user_id, app_id=app_id))
     if not any(a.id == artifact_id for a in existing):

--- a/llmcompressor-pipeline-quick-start/quantize-step/1/pipeline_step.py
+++ b/llmcompressor-pipeline-quick-start/quantize-step/1/pipeline_step.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""LLM Compressor quantization pipeline orchestrator.
+
+Drives scripts/quantize_llmcompressor.sh with the wrapper's defaults, then
+runs a HuggingFace transformers smoke test on the produced checkpoint, then
+optionally uploads the checkpoint as a Clarifai artifact.
+"""
+import argparse
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+# Step directory holding scripts/quantize_llmcompressor.sh + worker.
+STEP_DIR = Path(__file__).resolve().parent
+
+# Default output dir: /workspace/outputs/quantized_model in container, otherwise next to step.
+DEFAULT_OUT = "/workspace/outputs/quantized_model" if Path("/workspace").is_dir() \
+    else str(STEP_DIR.parent / "outputs" / "quantized_model")
+
+
+def run_quantization(src: str, scheme: str, out: str, num_gpus: str, pipeline: str) -> None:
+    cmd = [
+        "bash", str(STEP_DIR / "scripts" / "quantize_llmcompressor.sh"),
+        "--src", src,
+        "--out", out,
+        "--scheme", scheme,
+        "--num-gpus", num_gpus,
+        "--pipeline", pipeline,
+    ]
+    print(f"\n>>> running: {' '.join(cmd)}", flush=True)
+    subprocess.run(cmd, cwd=str(STEP_DIR), check=True)
+
+
+def sanity_check(out: str) -> None:
+    print(f"\n>>> sanity check: load {out} and generate", flush=True)
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+    m = AutoModelForCausalLM.from_pretrained(out, dtype="auto", device_map="auto")
+    tok = AutoTokenizer.from_pretrained(out)
+    inputs = tok.apply_chat_template(
+        [{"role": "user", "content": "Write a Python function that reverses a list."}],
+        return_tensors="pt", add_generation_prompt=True,
+    )
+    import torch
+    input_ids = inputs["input_ids"] if isinstance(inputs, dict) or hasattr(inputs, "data") else inputs
+    if not isinstance(input_ids, torch.Tensor):
+        input_ids = inputs.input_ids
+    input_ids = input_ids.to(m.device)
+    out_ids = m.generate(input_ids, max_new_tokens=200, do_sample=False)
+    print(tok.decode(out_ids[0][input_ids.shape[1]:], skip_special_tokens=True), flush=True)
+
+
+def upload_artifact(out: str, artifact_id: str, user_id: str, app_id: str) -> None:
+    """Zip the quantized checkpoint dir and upload as a Clarifai artifact version."""
+    from clarifai.client.artifact import Artifact
+    from clarifai.client.artifact_version import ArtifactVersion
+
+    archive_base = str(Path(out).parent / Path(out).name)
+    archive = shutil.make_archive(archive_base, "zip", root_dir=out)
+    print(f"\n>>> upload: {archive} -> user={user_id} app={app_id} artifact_id={artifact_id}",
+          flush=True)
+
+    existing = list(Artifact().list(user_id=user_id, app_id=app_id))
+    if not any(a.id == artifact_id for a in existing):
+        Artifact().create(artifact_id=artifact_id, user_id=user_id, app_id=app_id)
+
+    version = ArtifactVersion().upload(
+        file_path=archive,
+        artifact_id=artifact_id,
+        user_id=user_id,
+        app_id=app_id,
+    )
+    print(f">>> uploaded: artifact_id={artifact_id} version_id={version.id}", flush=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--src",       default="Qwen/Qwen2.5-0.5B-Instruct",
+                        help="HF repo id or local path. "
+                             "To try quantizing an MoE model, set to ibm-granite/granite-4.0-h-tiny "
+                             "(or any other MoE variant with a shim under "
+                             "llm-compressor/src/llmcompressor/modeling/).")
+    parser.add_argument("--scheme",    default="W4A16",
+                        help="Quantization scheme: W4A16, NVFP4, NVFP4A16, FP8, FP8_DYNAMIC, MXFP4, W8A8_INT8. "
+                             "To try the NVFP4 W4A4 variant (e.g. paired with the MoE example above), "
+                             "set to NVFP4 — or pick any other NVFP4 variant.")
+    parser.add_argument("--out",       default=DEFAULT_OUT)
+    parser.add_argument("--num_gpus",  default="1",
+                        help="GPUs auto-picked by lowest memory.used.")
+    parser.add_argument("--pipeline",  default="datafree",
+                        help="datafree (weight-only schemes), basic, sequential. "
+                             "When pairing with NVFP4 (or any scheme that needs activation calibration), "
+                             "set to '' (empty) and llm-compressor auto-infers sequential.")
+    parser.add_argument("--user_id",     default=os.environ.get("CLARIFAI_USER_ID", ""),
+                        help="Clarifai user id for artifact upload. Empty = skip upload.")
+    parser.add_argument("--app_id",      default=os.environ.get("CLARIFAI_APP_ID", ""),
+                        help="Clarifai app id for artifact upload. Empty = skip upload.")
+    parser.add_argument("--artifact_id", default="quantized-checkpoint",
+                        help="Clarifai artifact id (created if missing).")
+    args = parser.parse_args()
+
+    Path(args.out).mkdir(parents=True, exist_ok=True)
+
+    run_quantization(args.src, args.scheme, args.out, args.num_gpus, args.pipeline)
+    sanity_check(args.out)
+    upload_artifact(args.out, args.artifact_id, args.user_id, args.app_id)
+    print("\n=== pipeline_step.py done ===", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/llmcompressor-pipeline-quick-start/quantize-step/1/scripts/quantize_llmcompressor.sh
+++ b/llmcompressor-pipeline-quick-start/quantize-step/1/scripts/quantize_llmcompressor.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+# quantize_llmcompressor.sh — generic HF model -> NVFP4 (or other format)
+# quantization driver, using vLLM's llm-compressor as the backend.
+#
+# Usage:
+#   ./quantize_llmcompressor.sh --src <hf_id_or_path> --out <output_dir> [options]
+#
+# Quick examples:
+#   # Dense Llama
+#   ./quantize_llmcompressor.sh --src meta-llama/Llama-3.3-70B-Instruct --out /data/llama
+#
+#   # MoE — auto-adds router + vision exclusions
+#   ./quantize_llmcompressor.sh --src Qwen/Qwen3-30B-A3B-Instruct-2507 --out /data/qwen3
+#
+#   # Different scheme (W4A16 weight-only)
+#   ./quantize_llmcompressor.sh --src meta-llama/Llama-3.3-70B-Instruct --out /data/llama-w4a16 --scheme W4A16
+#
+# See ./quantize_llmcompressor.sh --help for all flags.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+# ---------- defaults --------------------------------------------------------
+
+SRC=""
+OUT=""
+SCHEME="NVFP4"
+EXTRA_IGNORE=""
+CALIB_DATASET="HuggingFaceH4/ultrachat_200k"
+CALIB_SPLIT="train_sft"
+CALIB_SIZE="512"
+CALIB_SEQ="2048"
+MOE_ALL_EXPERTS="true"
+PIPELINE=""        # empty = let llm-compressor infer (defaults to sequential)
+TRUST_REMOTE_CODE="true"
+AUTO_DEFAULTS="true"
+SAVE_UNCOMPRESSED="false"
+DTYPE="auto"
+GPUS=""
+NUM_GPUS=""
+DRY_RUN="false"
+WORKER="${WORKER:-$SCRIPT_DIR/quantize_llmcompressor_worker.py}"
+EXTRA_PY_ARGS=""
+
+# ---------- usage -----------------------------------------------------------
+
+usage() {
+  cat <<'EOF'
+quantize_llmcompressor.sh — generic HF -> NVFP4 driver via vLLM's llm-compressor
+
+REQUIRED
+  --src <hf_id_or_path>         Source HF repo id or local checkpoint dir
+  --out <path>                  Output directory for the quantized checkpoint
+
+QUANTIZATION
+  --scheme <name>               Default: NVFP4. Common values:
+                                  NVFP4         (W4A4 fp4 — Blackwell tensor cores)
+                                  NVFP4A16      (W4A16 — fp4 weights, bf16 activations)
+                                  FP8_DYNAMIC   (W8A8 fp8, dynamic per-token act)
+                                  FP8           (W8A8 fp8, per-tensor static)
+                                  W4A16         (int4 weight-only, AWQ-style)
+                                  MXFP4         (W4A4 mxfp4, OCP standard, Hopper-friendly)
+                                See compressed-tensors for the full preset list.
+  --ignore <csv>                Extra patterns to add to the ignore list, comma-separated.
+                                Use 're:<regex>' for regex. Merged with auto-defaults
+                                (--auto-defaults true) which adds router/vision/embed
+                                exclusions when MoE/VLM is detected.
+  --no-auto-defaults            Disable auto-detected ignore patterns; use only --ignore.
+
+CALIBRATION
+  --calib-dataset <hf_id>       Default: HuggingFaceH4/ultrachat_200k
+  --calib-split <name>          Default: train_sft
+                                (For datasets without an SFT split, try 'train'.)
+  --calib-size <int>            Default: 512
+  --calib-seq <int>             Max sequence length. Default: 2048
+  --moe-all-experts <bool>      true | false. Default: true. Forces every routed expert
+                                through calibration (critical for MoE accuracy).
+  --pipeline <name>             sequential | basic | independent | datafree.
+                                Default: inferred (sequential for QuantizationModifier).
+                                * sequential: layer-by-layer with error propagation.
+                                  Highest accuracy, slow (~10 min/layer × num_layers
+                                  with all-experts MoE calibration).
+                                * basic: single forward pass over all calib samples.
+                                  Much faster, small accuracy hit. Recommended for
+                                  iteration / large MoE models.
+                                * datafree: skip calibration entirely (only valid for
+                                  weight-only schemes like NVFP4A16, W4A16).
+
+EXECUTION
+  --no-trust-remote-code        Disable trust_remote_code (default: enabled)
+  --save-uncompressed           Save uncompressed safetensors (debug; bigger on disk)
+  --dtype <auto|bfloat16|float16>
+                                Model load dtype. Default: auto (uses model's torch_dtype).
+  --gpus <csv>                  CUDA_VISIBLE_DEVICES override. Mutually exclusive with --num-gpus.
+  --num-gpus <int>              Auto-pick this many least-loaded GPUs from nvidia-smi.
+  --worker <path>               Override the Python worker script path
+                                (default: <script_dir>/quantize_llmcompressor_worker.py)
+  --extra '<flags>'             Extra raw flags forwarded to the Python worker.
+  --dry-run                     Print every command and exit without executing.
+  -h, --help                    Show this help.
+EOF
+}
+
+# ---------- arg parsing -----------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --src)                  SRC="$2"; shift 2 ;;
+    --out)                  OUT="$2"; shift 2 ;;
+    --scheme)               SCHEME="$2"; shift 2 ;;
+    --ignore)               EXTRA_IGNORE="$2"; shift 2 ;;
+    --no-auto-defaults)     AUTO_DEFAULTS="false"; shift ;;
+    --calib-dataset)        CALIB_DATASET="$2"; shift 2 ;;
+    --calib-split)          CALIB_SPLIT="$2"; shift 2 ;;
+    --calib-size)           CALIB_SIZE="$2"; shift 2 ;;
+    --calib-seq)            CALIB_SEQ="$2"; shift 2 ;;
+    --moe-all-experts)      MOE_ALL_EXPERTS="$2"; shift 2 ;;
+    --pipeline)             PIPELINE="$2"; shift 2 ;;
+    --no-trust-remote-code) TRUST_REMOTE_CODE="false"; shift ;;
+    --save-uncompressed)    SAVE_UNCOMPRESSED="true"; shift ;;
+    --dtype)                DTYPE="$2"; shift 2 ;;
+    --gpus)                 GPUS="$2"; shift 2 ;;
+    --num-gpus)             NUM_GPUS="$2"; shift 2 ;;
+    --worker)               WORKER="$2"; shift 2 ;;
+    --extra)                EXTRA_PY_ARGS="$2"; shift 2 ;;
+    --dry-run)              DRY_RUN="true"; shift ;;
+    -h|--help)              usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+[[ -z "$SRC" ]]   && { echo "ERROR: --src is required" >&2; exit 2; }
+[[ -z "$OUT" ]]   && { echo "ERROR: --out is required" >&2; exit 2; }
+[[ -f "$WORKER" ]] || { echo "ERROR: worker script not found at $WORKER" >&2; exit 2; }
+
+run() {
+  echo "+ $*"
+  if [[ "$DRY_RUN" != "true" ]]; then
+    eval "$@"
+  fi
+}
+
+# ---------- pick GPUs -------------------------------------------------------
+
+pick_idle_gpus() {
+  local n="$1"
+  command -v nvidia-smi >/dev/null 2>&1 || {
+    echo "ERROR: --num-gpus needs nvidia-smi but it's not on PATH." >&2
+    exit 2
+  }
+  local query
+  query=$(nvidia-smi --query-gpu=index,memory.used,memory.free,name \
+                    --format=csv,noheader,nounits 2>/dev/null) || {
+    echo "ERROR: nvidia-smi query failed." >&2
+    exit 2
+  }
+  if [[ -z "$query" ]]; then
+    echo "ERROR: nvidia-smi returned no GPUs." >&2
+    exit 2
+  fi
+  local total
+  total=$(echo "$query" | wc -l)
+  if (( n > total )); then
+    echo "ERROR: --num-gpus $n requested but only $total GPU(s) visible." >&2
+    exit 2
+  fi
+  local picked
+  picked=$(echo "$query" | sort -t',' -k2,2n | head -n "$n")
+  echo "==> Auto-selected $n GPU(s) by lowest memory.used:" >&2
+  echo "$picked" | awk -F',' '{
+    gsub(/^ +| +$/, "", $1); gsub(/^ +| +$/, "", $2);
+    gsub(/^ +| +$/, "", $3); gsub(/^ +| +$/, "", $4);
+    printf "    [%s] %s  used=%s MiB  free=%s MiB\n", $1, $4, $2, $3
+  }' >&2
+  echo "$picked" | awk -F',' '{gsub(/ /,"",$1); print $1}' | paste -sd,
+}
+
+if [[ -n "$NUM_GPUS" && -n "$GPUS" ]]; then
+  echo "ERROR: --gpus and --num-gpus are mutually exclusive." >&2
+  exit 2
+fi
+if [[ -n "$NUM_GPUS" ]]; then
+  GPUS=$(pick_idle_gpus "$NUM_GPUS")
+fi
+
+# ---------- llmcompressor importable? --------------------------------------
+
+if ! python -c "import llmcompressor" >/dev/null 2>&1; then
+  echo "WARNING: 'import llmcompressor' failed in the active Python environment." >&2
+  echo "         Install with: pip install -e $SCRIPT_DIR/llm-compressor" >&2
+  echo "         or:           pip install llmcompressor" >&2
+fi
+
+# ---------- materialize HF repo to a local path ----------------------------
+# llmcompressor's oneshot path internally does from_pretrained(model_id) which
+# itself supports HF repo ids — but we still snapshot up-front so:
+#   * inspect can read config.json without auth/network indirection,
+#   * dtype/disk usage is predictable,
+#   * the same path works whether --src is a repo or a local dir.
+
+PYT_CKPT="$SRC"
+if [[ ! -d "$SRC" ]]; then
+  echo "==> Materializing HF snapshot for $SRC (cache: \${HF_HOME:-~/.cache/huggingface})"
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "    [dry-run] would call snapshot_download(repo_id=$SRC)"
+    PYT_CKPT="<local-snapshot-of-$SRC>"
+  else
+    PYT_CKPT=$(SRC="$SRC" python - <<'PYEOF'
+import os, sys
+from huggingface_hub import snapshot_download
+try:
+    print(snapshot_download(repo_id=os.environ["SRC"]))
+except Exception as e:
+    print(f"SNAPSHOT_DOWNLOAD_FAILED: {e}", file=sys.stderr)
+    sys.exit(1)
+PYEOF
+)
+    if [[ -z "$PYT_CKPT" || ! -d "$PYT_CKPT" ]]; then
+      echo "ERROR: snapshot_download did not return a usable local path." >&2
+      exit 1
+    fi
+    echo "    local path: $PYT_CKPT"
+  fi
+fi
+
+# ---------- run worker -----------------------------------------------------
+
+mkdir -p "$OUT"
+
+PY_ARGS=()
+PY_ARGS+=( --src "$PYT_CKPT" )
+PY_ARGS+=( --out "$OUT" )
+PY_ARGS+=( --scheme "$SCHEME" )
+PY_ARGS+=( --calib-dataset "$CALIB_DATASET" )
+PY_ARGS+=( --calib-split "$CALIB_SPLIT" )
+PY_ARGS+=( --calib-size "$CALIB_SIZE" )
+PY_ARGS+=( --calib-seq "$CALIB_SEQ" )
+PY_ARGS+=( --moe-all-experts "$MOE_ALL_EXPERTS" )
+PY_ARGS+=( --auto-defaults "$AUTO_DEFAULTS" )
+PY_ARGS+=( --dtype "$DTYPE" )
+[[ -n "$PIPELINE" ]] && PY_ARGS+=( --pipeline "$PIPELINE" )
+
+[[ -n "$EXTRA_IGNORE" ]] && PY_ARGS+=( --ignore "$EXTRA_IGNORE" )
+[[ "$TRUST_REMOTE_CODE" == "false" ]] && PY_ARGS+=( --no-trust-remote-code )
+[[ "$SAVE_UNCOMPRESSED" == "true" ]]  && PY_ARGS+=( --save-uncompressed )
+
+echo "==> Running llmcompressor worker"
+echo "    src        : $PYT_CKPT"
+echo "    out        : $OUT"
+echo "    scheme     : $SCHEME"
+echo "    calib      : $CALIB_DATASET split=$CALIB_SPLIT n=$CALIB_SIZE seq=$CALIB_SEQ"
+echo "    moe-all    : $MOE_ALL_EXPERTS"
+[[ -n "$PIPELINE" ]] && echo "    pipeline   : $PIPELINE"
+[[ -n "$EXTRA_IGNORE" ]] && echo "    extra ignore : $EXTRA_IGNORE"
+
+CMD=( python "$WORKER" "${PY_ARGS[@]}" )
+[[ -n "$EXTRA_PY_ARGS" ]] && CMD+=( $EXTRA_PY_ARGS )
+
+if [[ -n "$GPUS" ]]; then
+  CMD=( env CUDA_VISIBLE_DEVICES="$GPUS" "${CMD[@]}" )
+fi
+
+printf '+ '
+printf '%q ' "${CMD[@]}"
+printf '\n'
+if [[ "$DRY_RUN" != "true" ]]; then
+  "${CMD[@]}"
+fi
+
+# ---------- verify ---------------------------------------------------------
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "==> Dry run finished. No commands executed."
+  exit 0
+fi
+
+echo "==> Verifying output at $OUT"
+if [[ ! -f "$OUT/config.json" ]]; then
+  echo "ERROR: $OUT/config.json missing — quantization did not produce a checkpoint." >&2
+  exit 1
+fi
+
+du -sh "$OUT"
+OUT="$OUT" python - <<'PYEOF'
+import json, os
+out = os.environ["OUT"]
+with open(os.path.join(out, "config.json")) as f:
+    cfg = json.load(f)
+qc = cfg.get("quantization_config", {})
+if not qc:
+    print("WARNING: quantization_config missing from config.json")
+else:
+    print("quantization_config (first 1500 chars):")
+    print(json.dumps(qc, indent=2)[:1500])
+PYEOF
+
+echo "==> Done. Checkpoint: $OUT"

--- a/llmcompressor-pipeline-quick-start/quantize-step/1/scripts/quantize_llmcompressor_worker.py
+++ b/llmcompressor-pipeline-quick-start/quantize-step/1/scripts/quantize_llmcompressor_worker.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python
+"""
+quantize_llmcompressor_worker.py — Python worker invoked by quantize_llmcompressor.sh.
+
+You normally don't run this directly — the bash driver handles GPU selection,
+HF snapshot materialization, etc. before invoking this. Run it standalone
+only if you need to bypass the wrapper.
+
+The worker:
+  1. Loads the (already-local) HF model + tokenizer/processor.
+  2. Builds a `QuantizationModifier` recipe with sensible defaults based on
+     the model's architecture (MoE / VLM / dense).
+  3. Loads & preprocesses a calibration dataset (chat-template aware).
+  4. Calls llmcompressor.oneshot(...).
+  5. Saves the compressed-tensors checkpoint to --out.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+# We import torch / transformers / llmcompressor lazily so that --help and
+# argument validation work even if the env isn't fully set up yet.
+
+
+def _add_default_ignore_patterns(ignore: list[str], cfg: dict) -> list[str]:
+    """Augment the user-provided ignore list with sensible defaults for the
+    detected architecture. Patterns use llmcompressor / compressed-tensors
+    conventions: prefix with 're:' for regex, otherwise exact-match."""
+    out = list(ignore)
+
+    def add(p):
+        if p not in out:
+            out.append(p)
+
+    # Universally needed
+    add("lm_head")
+
+    # MoE indicators
+    is_moe = any(
+        isinstance(cfg.get(k) or (cfg.get("text_config") or {}).get(k), int)
+        and (cfg.get(k) or (cfg.get("text_config") or {}).get(k)) > 1
+        for k in (
+            "num_local_experts",
+            "n_routed_experts",
+            "num_experts",
+            "moe_num_experts",
+        )
+    )
+    if is_moe:
+        # Most MoE archs name the router `mlp.gate` (DeepSeek/Kimi/Qwen3-MoE)
+        # or `mlp.router` (GLM4 newer). Cover both. Anchor with $ so we don't
+        # accidentally hit `gate_proj`.
+        add("re:.*mlp.gate$")
+        add("re:.*mlp.router$")
+        add("re:.*router$")
+        # Some archs (DeepSeek-V3) have a mixer/conv attribute that should
+        # stay in BF16; the `re:.*linear_attn.*` pattern covers Qwen3.5/3-Next
+        # hybrid linear-attention layers.
+        add("re:.*linear_attn.*")
+        # Shared-expert gates (Qwen3.5 etc.) are scalar gating coefficients.
+        add("re:.*shared_expert_gate$")
+
+    # VLM indicators — keep vision tower in BF16
+    if any(k in cfg for k in ("vision_config", "vision_tower_config")) or any(
+        k in cfg for k in ("image_token_id", "video_token_id")
+    ):
+        add("re:.*vision_tower.*")
+        add("re:visual.*")
+        add("re:.*vision_model.*")
+        add("re:.*embed_vision.*")
+
+    # Embeddings should always stay in BF16 — they aren't `Linear` so most
+    # recipes won't touch them, but exact-name pattern catches any custom
+    # embedding linears (e.g. multimodal `embed_*`).
+    add("re:.*embed_tokens$")
+
+    return out
+
+
+def _detect_arch(cfg: dict) -> dict:
+    """Cheap structural classification used for logging and recipe defaults."""
+    info = {
+        "model_type": cfg.get("model_type"),
+        "architectures": cfg.get("architectures") or [],
+        "is_vlm": any(
+            k in cfg for k in ("vision_config", "vision_tower_config", "image_token_id")
+        ),
+        "is_moe": False,
+        "n_experts": None,
+        "n_layers": cfg.get("num_hidden_layers")
+        or (cfg.get("text_config") or {}).get("num_hidden_layers"),
+    }
+    text_cfg = cfg.get("text_config") or {}
+    for src in (cfg, text_cfg):
+        for k in ("num_local_experts", "n_routed_experts", "num_experts", "moe_num_experts"):
+            v = src.get(k)
+            if isinstance(v, int) and v > 1:
+                info["is_moe"] = True
+                info["n_experts"] = v
+                return info
+    return info
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--src", required=True, help="Local checkpoint dir (or HF repo id).")
+    p.add_argument("--out", required=True, help="Output dir for the NVFP4 checkpoint.")
+    p.add_argument(
+        "--scheme",
+        default="NVFP4",
+        help="Quantization scheme. Common values: NVFP4 (W4A4 fp4),"
+        " NVFP4A16 (W4A16 fp4 weight-only), FP8_DYNAMIC, FP8 (per-tensor),"
+        " W4A16 (int4 weight-only), MXFP4. See compressed-tensors for the full list.",
+    )
+    p.add_argument(
+        "--ignore",
+        default="",
+        help="Extra ignore patterns, comma-separated. Use 're:<regex>' for regex,"
+        " bare strings for exact matches. Merged with auto-detected defaults"
+        " (MoE router, vision tower, embeddings).",
+    )
+    p.add_argument("--calib-dataset", default="HuggingFaceH4/ultrachat_200k")
+    p.add_argument(
+        "--calib-split",
+        default="train_sft",
+        help='Dataset split (e.g. "train_sft", "train", "train[:5%%]").',
+    )
+    p.add_argument("--calib-size", type=int, default=512)
+    p.add_argument("--calib-seq", type=int, default=2048)
+    p.add_argument(
+        "--moe-all-experts",
+        choices=["true", "false"],
+        default="true",
+        help="Force every routed expert through calibration. Default: true.",
+    )
+    p.add_argument(
+        "--pipeline",
+        choices=["sequential", "basic", "independent", "datafree"],
+        default=None,
+        help="Calibration pipeline. Default: let llm-compressor infer "
+        "(picks 'sequential' for QuantizationModifier — slow, ~10 min/layer "
+        "on 30B-class MoE models with all-experts calibration). "
+        "Use 'basic' for a single forward pass over all calib samples "
+        "(~5-30 min total, ~0.5%% accuracy hit on MMLU vs sequential). "
+        "Use 'datafree' for weight-only schemes (NVFP4A16, W4A16) — "
+        "skips activation calibration entirely.",
+    )
+    p.add_argument(
+        "--no-trust-remote-code",
+        action="store_true",
+        help="Disable trust_remote_code (default: enabled for unrecognized arches).",
+    )
+    p.add_argument(
+        "--save-uncompressed",
+        action="store_true",
+        help="Pass save_compressed=False to save_pretrained (raw fp4 tensors,"
+        " bigger on disk, useful for debugging).",
+    )
+    p.add_argument(
+        "--auto-defaults",
+        choices=["true", "false"],
+        default="true",
+        help="Add MoE / VLM / lm_head ignore patterns automatically based on"
+        " config.json. Default: true.",
+    )
+    p.add_argument(
+        "--dtype",
+        default="auto",
+        help="Model load dtype. 'auto' uses the model's config.json torch_dtype.",
+    )
+    args = p.parse_args()
+
+    src = args.src
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Inspect config to drive default ignore-list and detect VLM
+    # ------------------------------------------------------------------
+    config_path = Path(src) / "config.json"
+    if not config_path.exists():
+        print(f"ERROR: {config_path} missing — --src must be a local directory "
+              "(snapshot it first via the bash driver).", file=sys.stderr)
+        return 2
+    cfg = json.loads(config_path.read_text())
+    arch = _detect_arch(cfg)
+    print(f"[inspect] model_type={arch['model_type']}  "
+          f"architectures={arch['architectures']}  "
+          f"is_moe={arch['is_moe']}  n_experts={arch['n_experts']}  "
+          f"is_vlm={arch['is_vlm']}  n_layers={arch['n_layers']}")
+
+    # ------------------------------------------------------------------
+    # Build ignore list
+    # ------------------------------------------------------------------
+    user_ignore = [p.strip() for p in args.ignore.split(",") if p.strip()]
+    if args.auto_defaults == "true":
+        ignore = _add_default_ignore_patterns(user_ignore, cfg)
+    else:
+        ignore = user_ignore or ["lm_head"]
+    print(f"[recipe] scheme={args.scheme}  ignore={ignore}")
+
+    # ------------------------------------------------------------------
+    # Load model + tokenizer/processor (now the heavy imports happen)
+    # ------------------------------------------------------------------
+    import torch  # noqa: F401 (used implicitly by HF / llmcompressor)
+    from transformers import AutoModelForCausalLM, AutoProcessor, AutoTokenizer
+
+    print(f"[load] model from {src}  dtype={args.dtype}")
+    trust = not args.no_trust_remote_code
+    model_kwargs = {"dtype": args.dtype, "trust_remote_code": trust}
+
+    # VLMs typically need AutoProcessor; pure-text LLMs use AutoTokenizer.
+    # For multimodal architectures the right `from_pretrained` class is the
+    # explicit `Foo4ForConditionalGeneration` — but `AutoModelForCausalLM`
+    # works for the language-only variants and most VLMs that ship a
+    # text-CausalLM config. If the user hits a model where this fails, they
+    # can pre-load the model and pass it via the Python API.
+    model = AutoModelForCausalLM.from_pretrained(src, **model_kwargs)
+    try:
+        processor = AutoProcessor.from_pretrained(src, trust_remote_code=trust)
+        tokenizer = getattr(processor, "tokenizer", None)
+        if tokenizer is None:
+            tokenizer = AutoTokenizer.from_pretrained(src, trust_remote_code=trust)
+    except Exception:
+        processor = None
+        tokenizer = AutoTokenizer.from_pretrained(src, trust_remote_code=trust)
+
+    # ------------------------------------------------------------------
+    # Calibration dataset — chat-template aware
+    # ------------------------------------------------------------------
+    print(f"[calib] dataset={args.calib_dataset}  split={args.calib_split}  "
+          f"n={args.calib_size}  seq={args.calib_seq}")
+    from datasets import load_dataset
+
+    split_spec = f"{args.calib_split}[:{args.calib_size}]"
+    ds = load_dataset(args.calib_dataset, split=split_spec)
+    ds = ds.shuffle(seed=42)
+
+    has_messages = "messages" in ds.column_names
+    has_text = "text" in ds.column_names
+
+    def preprocess(example):
+        if has_messages:
+            return {
+                "text": tokenizer.apply_chat_template(
+                    example["messages"], tokenize=False
+                )
+            }
+        if has_text:
+            return {"text": example["text"]}
+        # Fallback: stringify whatever the first column has.
+        first_col = ds.column_names[0]
+        return {"text": str(example[first_col])}
+
+    ds = ds.map(preprocess)
+
+    def tokenize(sample):
+        return tokenizer(
+            sample["text"],
+            padding=False,
+            max_length=args.calib_seq,
+            truncation=True,
+            add_special_tokens=False,
+        )
+
+    ds = ds.map(tokenize, remove_columns=ds.column_names)
+
+    # ------------------------------------------------------------------
+    # Quantize
+    # ------------------------------------------------------------------
+    from llmcompressor import oneshot
+    from llmcompressor.modifiers.quantization import QuantizationModifier
+
+    recipe = QuantizationModifier(
+        targets="Linear",
+        scheme=args.scheme,
+        ignore=ignore,
+    )
+    moe_all = args.moe_all_experts == "true"
+    print(f"[oneshot] moe_calibrate_all_experts={moe_all}  pipeline={args.pipeline or '(inferred)'}")
+
+    oneshot_kwargs = dict(
+        model=model,
+        dataset=ds,
+        recipe=recipe,
+        max_seq_length=args.calib_seq,
+        num_calibration_samples=args.calib_size,
+        moe_calibrate_all_experts=moe_all,
+        tokenizer=tokenizer,
+    )
+    if args.pipeline is not None:
+        oneshot_kwargs["pipeline"] = args.pipeline
+    oneshot(**oneshot_kwargs)
+
+    # ------------------------------------------------------------------
+    # Save
+    # ------------------------------------------------------------------
+    print(f"[save] writing to {out}  save_compressed={not args.save_uncompressed}")
+    model.save_pretrained(str(out), save_compressed=not args.save_uncompressed)
+    if processor is not None:
+        processor.save_pretrained(str(out))
+    else:
+        tokenizer.save_pretrained(str(out))
+
+    print(f"[done] checkpoint at: {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/llmcompressor-pipeline-quick-start/quantize-step/1/scripts/quantize_llmcompressor_worker.py
+++ b/llmcompressor-pipeline-quick-start/quantize-step/1/scripts/quantize_llmcompressor_worker.py
@@ -36,8 +36,11 @@ def _add_default_ignore_patterns(ignore: list[str], cfg: dict) -> list[str]:
         if p not in out:
             out.append(p)
 
-    # Universally needed
+    # Universally needed. The `lm_head` exact pattern catches the top-level
+    # module; `re:.*lm_head$` also catches nested forms like
+    # `language_model.lm_head` (common in VLMs / audio multimodals).
     add("lm_head")
+    add("re:.*lm_head$")
 
     # MoE indicators
     is_moe = any(
@@ -57,21 +60,73 @@ def _add_default_ignore_patterns(ignore: list[str], cfg: dict) -> list[str]:
         add("re:.*mlp.gate$")
         add("re:.*mlp.router$")
         add("re:.*router$")
-        # Some archs (DeepSeek-V3) have a mixer/conv attribute that should
-        # stay in BF16; the `re:.*linear_attn.*` pattern covers Qwen3.5/3-Next
-        # hybrid linear-attention layers.
-        add("re:.*linear_attn.*")
         # Shared-expert gates (Qwen3.5 etc.) are scalar gating coefficients.
         add("re:.*shared_expert_gate$")
 
-    # VLM indicators — keep vision tower in BF16
-    if any(k in cfg for k in ("vision_config", "vision_tower_config")) or any(
-        k in cfg for k in ("image_token_id", "video_token_id")
+    # Built-in MTP / multi-token-prediction heads used for in-model
+    # speculative decoding (Qwen3-Next, Qwen3.5, Qwen3.6, DeepSeek-V3 MTP).
+    # Quantizing these tiny modules to W4A4 risks tanking the speculative
+    # accept-rate while giving negligible compression savings. Detect via
+    # `mtp_num_hidden_layers` (or nested under text_config for VLMs).
+    text_cfg = cfg.get("text_config") or {}
+    if any(
+        isinstance(src.get("mtp_num_hidden_layers"), int)
+        and src.get("mtp_num_hidden_layers") > 0
+        for src in (cfg, text_cfg)
     ):
+        add("re:^mtp\\..*")
+        add("re:.*\\.mtp\\..*")
+
+    # Hybrid attention paths — small but precision-sensitive sub-modules that
+    # don't benefit from W4A4 and tend to drift quality when quantized. Apply
+    # to BOTH MoE and dense models; Qwen3.5 / Qwen3.6 / Qwen3-Next include
+    # `linear_attn` paths even in their dense variants.
+    add("re:.*linear_attn.*")
+    add("re:.*mamba.*")
+    add("re:.*ssm.*")
+    # Mamba/SSM 1-D conv (Falcon-Mamba, Mamba-2, Jamba, NemotronH). The
+    # convs are nn.Conv1d (not nn.Linear) so `targets="Linear"` already
+    # excludes them, but be defensive — some recipes broaden targets and
+    # we don't want a Conv1d weight ever quantized.
+    # Note: do NOT exclude the whole `*.mixer.*` subtree — Mamba's
+    # in_proj/out_proj/x_proj/dt_proj are nn.Linear and CAN be NVFP4'd.
+    add("re:.*\\.conv1d\\..*")
+    add("re:.*\\.conv1d$")
+
+    # VLM indicators — keep vision tower in BF16. Patterns intentionally use
+    # a leading `.*` because module paths are typically `model.<sub>.…` — a
+    # bare `re:visual.*` does NOT match `model.visual.blocks.0.…` (it would
+    # only match names *starting* with `visual`).
+    is_vlm = any(k in cfg for k in ("vision_config", "vision_tower_config")) or any(
+        k in cfg for k in ("image_token_id", "video_token_id")
+    )
+    # Audio multimodal indicators (Qwen2-Audio, Whisper-style stacks, Phi-4
+    # multimodal etc.). Detection mirrors the VLM check on audio-side keys.
+    is_audio_mm = any(k in cfg for k in ("audio_config", "audio_tower_config")) or any(
+        k in cfg for k in ("audio_token_id", "audio_token_index")
+    )
+    if is_vlm or is_audio_mm:
+        # Vision side
         add("re:.*vision_tower.*")
-        add("re:visual.*")
+        add("re:.*\\.visual\\..*")        # `model.visual.…` (Qwen3.5/3.6 VLM)
+        add("re:.*\\.visual$")            # the visual submodule attribute itself
         add("re:.*vision_model.*")
+        add("re:.*vision_encoder.*")
+        add("re:.*visual_encoder.*")
+        add("re:.*visual_tower.*")
         add("re:.*embed_vision.*")
+        add("re:.*image_processor.*")
+        add("re:.*image_proj.*")
+        add("re:.*image_embedding.*")
+        add("re:.*patch_embed.*")
+        add("re:.*mm_projector.*")        # LLaVA-style multimodal projector
+        add("re:.*multi_modal_projector.*")
+        # Audio side
+        add("re:.*audio_tower.*")          # Qwen2-Audio path: `audio_tower.…`
+        add("re:.*audio_encoder.*")
+        add("re:.*audio_model.*")
+        add("re:.*audio_proj.*")
+        add("re:.*audio_embed.*")
 
     # Embeddings should always stay in BF16 — they aren't `Linear` so most
     # recipes won't touch them, but exact-name pattern catches any custom
@@ -79,6 +134,149 @@ def _add_default_ignore_patterns(ignore: list[str], cfg: dict) -> list[str]:
     add("re:.*embed_tokens$")
 
     return out
+
+
+def _restore_mtp_weights(out_dir: Path, src_dir: str) -> None:
+    """Some loader classes (Qwen3_5ForConditionalGeneration, Qwen3NextForCausalLM,
+    DeepSeek-V3 multimodal variants) set `_keys_to_ignore_on_load_unexpected`
+    to drop top-level `mtp.*` weights during from_pretrained — MTP is loaded
+    later by the inference engine, not the HF model class. The downside is
+    that `save_pretrained` then writes a checkpoint with no MTP, and vLLM /
+    SGLang spec decoding (`--speculative-config qwen3_next_mtp`) breaks.
+
+    This copies MTP tensors from the source snapshot into the output as a
+    new BF16 shard and rebuilds `model.safetensors.index.json`. No-op when
+    the source has no MTP or when MTP already survived the round-trip.
+    """
+    import json
+    import shutil
+    from collections import defaultdict
+    from safetensors import safe_open
+    from safetensors.torch import save_file
+
+    src_p = Path(src_dir)
+
+    src_index = src_p / "model.safetensors.index.json"
+    if src_index.exists():
+        src_weight_map = json.loads(src_index.read_text())["weight_map"]
+    elif (src_p / "model.safetensors").exists():
+        with safe_open(src_p / "model.safetensors", framework="pt") as f:
+            src_weight_map = {k: "model.safetensors" for k in f.keys()}
+    else:
+        return
+
+    mtp_keys = sorted(k for k in src_weight_map if k.startswith("mtp.") or ".mtp." in k)
+    if not mtp_keys:
+        return
+
+    out_index = out_dir / "model.safetensors.index.json"
+    out_single = out_dir / "model.safetensors"
+    if out_index.exists():
+        existing_weight_map = dict(json.loads(out_index.read_text())["weight_map"])
+        existing_files = sorted(set(existing_weight_map.values()))
+    elif out_single.exists():
+        with safe_open(out_single, framework="pt") as f:
+            existing_weight_map = {k: "model.safetensors" for k in f.keys()}
+        existing_files = ["model.safetensors"]
+    else:
+        shards = sorted(out_dir.glob("model-*-of-*.safetensors"))
+        if not shards:
+            return
+        existing_weight_map = {}
+        for sh in shards:
+            with safe_open(sh, framework="pt") as f:
+                for k in f.keys():
+                    existing_weight_map[k] = sh.name
+        existing_files = [sh.name for sh in shards]
+
+    if any(k.startswith("mtp.") or ".mtp." in k for k in existing_weight_map):
+        print("[mtp-restore] MTP weights already present in output — no patch needed.")
+        return
+
+    print(f"[mtp-restore] Source has {len(mtp_keys)} MTP tensors that the loader class "
+          f"dropped on save; restoring as a BF16 shard alongside quantized weights.")
+
+    shard_to_keys = defaultdict(list)
+    for k in mtp_keys:
+        shard_to_keys[src_weight_map[k]].append(k)
+    mtp_tensors = {}
+    mtp_bytes = 0
+    for sh, keys in shard_to_keys.items():
+        with safe_open(src_p / sh, framework="pt") as f:
+            for k in keys:
+                t = f.get_tensor(k)
+                mtp_tensors[k] = t
+                mtp_bytes += t.element_size() * t.numel()
+
+    dtype_bytes = {
+        "BF16": 2, "F16": 2, "F32": 4, "F64": 8,
+        "F8_E4M3": 1, "F8_E5M2": 1,
+        "U8": 1, "I8": 1, "I32": 4, "I64": 8, "BOOL": 1,
+    }
+    existing_bytes = 0
+    for fname in existing_files:
+        with safe_open(out_dir / fname, framework="pt") as f:
+            for k in f.keys():
+                sl = f.get_slice(k)
+                shape = sl.get_shape()
+                sz = dtype_bytes.get(sl.get_dtype().upper(), 4)
+                n = 1
+                for d in shape:
+                    n *= d
+                existing_bytes += n * sz
+
+    new_total = len(existing_files) + 1
+    rename_map = {}
+    for i, old in enumerate(existing_files, start=1):
+        rename_map[old] = f"model-{i:05d}-of-{new_total:05d}.safetensors"
+    for old, new in rename_map.items():
+        if old != new:
+            shutil.move(str(out_dir / old), str(out_dir / new))
+
+    new_weight_map = {k: rename_map[v] for k, v in existing_weight_map.items()}
+    mtp_name = f"model-{new_total:05d}-of-{new_total:05d}.safetensors"
+    save_file(mtp_tensors, str(out_dir / mtp_name), metadata={"format": "pt"})
+    for k in mtp_tensors:
+        new_weight_map[k] = mtp_name
+
+    total_size = existing_bytes + mtp_bytes
+    out_index.write_text(json.dumps(
+        {"metadata": {"total_size": total_size}, "weight_map": new_weight_map},
+        indent=2,
+    ))
+    print(f"[mtp-restore] Wrote {new_total}-shard layout, "
+          f"{len(existing_weight_map)} quantized + {len(mtp_keys)} MTP keys, "
+          f"total_size={total_size / 1024 ** 3:.2f} GiB")
+
+    # Patch quantization_config.ignore in config.json. The recipe-time `re:^mtp\..*`
+    # regex never matched anything because the Qwen3_5/Qwen3_6/Next loader class
+    # discarded MTP on load — so the saved `ignore` list (the *expanded* form
+    # llmcompressor walks from the live model) has zero MTP entries. Without
+    # this, vLLM's compressed-tensors loader wraps every MTP Linear with NVFP4
+    # weight_packed / weight_scale parameters and fails to load the BF16 MTP
+    # weights we just restored — silently leaving MTP at random init, killing
+    # spec-decoding accept rate.
+    cfg_path = out_dir / "config.json"
+    if cfg_path.exists():
+        cfg = json.loads(cfg_path.read_text())
+        qc = cfg.get("quantization_config")
+        if qc and isinstance(qc.get("ignore"), list):
+            mtp_linear_modules = set()
+            for k in mtp_tensors:
+                if not k.endswith(".weight"):
+                    continue
+                if mtp_tensors[k].dim() == 2:
+                    mtp_linear_modules.add(k[: -len(".weight")])
+            added = 0
+            for m in sorted(mtp_linear_modules):
+                if m not in qc["ignore"]:
+                    qc["ignore"].append(m)
+                    added += 1
+            if added:
+                cfg_path.write_text(json.dumps(cfg, indent=2))
+                print(f"[mtp-restore] Patched quantization_config.ignore "
+                      f"with {added} MTP Linear module names "
+                      f"(prevents vLLM from wrapping them as NVFP4).")
 
 
 def _detect_arch(cfg: dict) -> dict:
@@ -210,19 +408,45 @@ def main() -> int:
     # Load model + tokenizer/processor (now the heavy imports happen)
     # ------------------------------------------------------------------
     import torch  # noqa: F401 (used implicitly by HF / llmcompressor)
+    import transformers
     from transformers import AutoModelForCausalLM, AutoProcessor, AutoTokenizer
 
     print(f"[load] model from {src}  dtype={args.dtype}")
     trust = not args.no_trust_remote_code
     model_kwargs = {"dtype": args.dtype, "trust_remote_code": trust}
 
-    # VLMs typically need AutoProcessor; pure-text LLMs use AutoTokenizer.
-    # For multimodal architectures the right `from_pretrained` class is the
-    # explicit `Foo4ForConditionalGeneration` — but `AutoModelForCausalLM`
-    # works for the language-only variants and most VLMs that ship a
-    # text-CausalLM config. If the user hits a model where this fails, they
-    # can pre-load the model and pass it via the Python API.
-    model = AutoModelForCausalLM.from_pretrained(src, **model_kwargs)
+    # Loader strategy:
+    #   * For VLMs: load via the explicit class declared in config.json
+    #     `architectures` field (e.g. Qwen3_5ForConditionalGeneration). This
+    #     preserves the full multimodal structure — vision tower, vision_config,
+    #     embed_vision, etc. — in both the live model and the saved
+    #     state_dict/config.json. Required so vLLM's multimodal dispatchers
+    #     can load the resulting checkpoint (vLLM's qwen3_5 / gemma4 / llama4
+    #     model registries route through the multimodal pipeline and expect a
+    #     full Foo*Config with vision_config; AutoModelForCausalLM-saved
+    #     checkpoints fail there with "Invalid type of HuggingFace config").
+    #   * For non-VLM models: AutoModelForCausalLM is the right loader.
+    #
+    # Vision-tower Linears stay BF16 in either case via the auto-defaults
+    # ignore list (`re:.*vision_tower.*`, `re:visual.*`, etc.). What changes
+    # is whether the vision components survive in the saved checkpoint at all.
+    loader_class = None
+    if arch.get("is_vlm") and arch.get("architectures"):
+        arch_name = arch["architectures"][0]
+        loader_class = getattr(transformers, arch_name, None)
+        if loader_class is not None:
+            print(f"[load] VLM detected; using {arch_name}.from_pretrained "
+                  "(preserves vision_config in saved checkpoint)")
+        else:
+            print(f"[load] VLM detected but {arch_name!r} not in transformers "
+                  "namespace; falling back to AutoModelForCausalLM "
+                  "(saved checkpoint will be text-only)")
+
+    if loader_class is not None:
+        model = loader_class.from_pretrained(src, **model_kwargs)
+    else:
+        model = AutoModelForCausalLM.from_pretrained(src, **model_kwargs)
+
     try:
         processor = AutoProcessor.from_pretrained(src, trust_remote_code=trust)
         tokenizer = getattr(processor, "tokenizer", None)
@@ -308,6 +532,8 @@ def main() -> int:
         processor.save_pretrained(str(out))
     else:
         tokenizer.save_pretrained(str(out))
+
+    _restore_mtp_weights(out, src)
 
     print(f"[done] checkpoint at: {out}")
     return 0

--- a/llmcompressor-pipeline-quick-start/quantize-step/Dockerfile
+++ b/llmcompressor-pipeline-quick-start/quantize-step/Dockerfile
@@ -1,0 +1,39 @@
+ARG BASE_IMAGE=nvcr.io/nvidia/pytorch:25.10-py3
+FROM ${BASE_IMAGE}
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    HF_HOME=/home/nonroot/cache/huggingface \
+    HF_HUB_ENABLE_HF_TRANSFER=1 \
+    HF_HUB_DOWNLOAD_TIMEOUT=600 \
+    LLMC_DIR=/opt/llm-compressor \
+    LLMC_REF=7a52e9e
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git tmux htop jq less procps bc \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pinned llm-compressor commit + transitive deps (compressed-tensors etc.).
+# main HEAD imports from transformers internals that drift weekly; this commit
+# + the pins below form a tested set on nvcr.io/nvidia/pytorch:25.10-py3.
+RUN git clone https://github.com/vllm-project/llm-compressor.git "$LLMC_DIR" \
+    && git -C "$LLMC_DIR" checkout "$LLMC_REF" \
+    && python3 -m pip install --ignore-installed -e "$LLMC_DIR"
+
+# transformers 5.7 has a keras_nlp BACKENDS_MAPPING regression; 5.2 imports cleanly.
+# huggingface_hub must be >=1.5,<2 for transformers 5.x.
+# torchvision must match torch 2.11 (base image ships torch-2.9-pinned torchvision).
+# compressed-tensors 0.15.1.a20260421 has the FP4 weight_scale fix and matches the LLMC_REF API.
+RUN python3 -m pip install --no-cache-dir --upgrade \
+        "transformers==5.2.0" "huggingface-hub>=1.5,<2" torchvision \
+    && python3 -m pip install --no-cache-dir --force-reinstall --no-deps \
+        "compressed-tensors==0.15.1.a20260421"
+
+COPY --link requirements.txt /home/nonroot/main/requirements.txt
+RUN python3 -m pip install --ignore-installed -r /home/nonroot/main/requirements.txt
+
+COPY --link 1 /home/nonroot/main/1
+COPY --link config.yaml /home/nonroot/main/config.yaml
+
+WORKDIR /home/nonroot/main

--- a/llmcompressor-pipeline-quick-start/quantize-step/config.yaml
+++ b/llmcompressor-pipeline-quick-start/quantize-step/config.yaml
@@ -1,0 +1,54 @@
+pipeline_step:
+  id: "quantize-step"
+  user_id: "<YOUR_USER_ID>"
+  app_id: "<YOUR_APP_ID>"
+
+build_info:
+  python_version: "3.12"
+  platform: "linux/amd64,linux/arm64"
+
+pipeline_step_compute_info:
+  cpu_limit: "8000m"
+  cpu_memory: "32Gi"
+  num_accelerators: 1
+  accelerator_memory: "40Gi"
+  accelerator_type: ["NVIDIA-*"]
+
+pipeline_step_input_params:
+  - name: src
+    default: "Qwen/Qwen2.5-0.5B-Instruct"
+    description: "HF repo id or local path. For an MoE example, set to ibm-granite/granite-4.0-h-tiny."
+  - name: scheme
+    default: "W4A16"
+    description: "Quantization scheme: W4A16, NVFP4, NVFP4A16, FP8, FP8_DYNAMIC, MXFP4, W8A8_INT8."
+    accepted_values:
+      - "W4A16"
+      - "NVFP4"
+      - "NVFP4A16"
+      - "FP8"
+      - "FP8_DYNAMIC"
+      - "MXFP4"
+      - "W8A8_INT8"
+  - name: pipeline
+    default: "datafree"
+    description: "datafree (weight-only schemes), basic, sequential. Set to '' (empty) to let llm-compressor auto-infer."
+    accepted_values:
+      - "datafree"
+      - "basic"
+      - "sequential"
+      - ""
+  - name: num_gpus
+    default: "1"
+    description: "Number of GPUs auto-picked by lowest memory.used."
+  - name: out
+    default: "/workspace/outputs/quantized_model"
+    description: "Output directory for the quantized checkpoint."
+  - name: user_id
+    default: ""
+    description: "Clarifai user id for artifact upload. Empty = skip upload."
+  - name: app_id
+    default: ""
+    description: "Clarifai app id for artifact upload. Empty = skip upload."
+  - name: artifact_id
+    default: "quantized-checkpoint"
+    description: "Clarifai artifact id (created if missing)."

--- a/llmcompressor-pipeline-quick-start/quantize-step/requirements.txt
+++ b/llmcompressor-pipeline-quick-start/quantize-step/requirements.txt
@@ -1,0 +1,7 @@
+clarifai>=12.3
+accelerate>=1.0.0
+safetensors>=0.5.2
+datasets>=3.0.0
+huggingface_hub[hf_transfer]>=0.30.0
+sentencepiece
+protobuf

--- a/llmcompressor-pipeline-quick-start/test_download_and_sanity.py
+++ b/llmcompressor-pipeline-quick-start/test_download_and_sanity.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Download a quantized-checkpoint Clarifai artifact, unzip it, and run a
+load + chat-template generate sanity check on the produced model.
+
+Required env: CLARIFAI_PAT.
+Required argv: --user_id --app_id --artifact_id [--version_id]
+If --version_id is omitted, the most recent version of the artifact is used.
+"""
+import argparse
+import os
+import shutil
+import zipfile
+from pathlib import Path
+
+
+def resolve_latest_version(user_id: str, app_id: str, artifact_id: str) -> str:
+    from clarifai.client.artifact_version import ArtifactVersion
+    versions = list(ArtifactVersion().list(
+        artifact_id=artifact_id, user_id=user_id, app_id=app_id, per_page=50,
+    ))
+    if not versions:
+        raise SystemExit(f"No versions found for artifact {user_id}/{app_id}/{artifact_id}")
+    versions.sort(
+        key=lambda v: getattr(v, "created_at", None).seconds if getattr(v, "created_at", None) else 0,
+        reverse=True,
+    )
+    print(f">>> resolved latest version_id={versions[0].id} (out of {len(versions)} versions)",
+          flush=True)
+    return versions[0].id
+
+
+def download_artifact(user_id: str, app_id: str, artifact_id: str, version_id: str,
+                      out_dir: str) -> str:
+    from clarifai.client.artifact_version import ArtifactVersion
+
+    Path(out_dir).mkdir(parents=True, exist_ok=True)
+    zip_path = str(Path(out_dir) / f"{artifact_id}.zip")
+    print(f">>> downloading artifact_id={artifact_id} version_id={version_id} -> {zip_path}",
+          flush=True)
+    ArtifactVersion().download(
+        output_path=zip_path,
+        artifact_id=artifact_id,
+        version_id=version_id,
+        user_id=user_id,
+        app_id=app_id,
+        force=True,
+    )
+    return zip_path
+
+
+def unzip(zip_path: str, dest: str) -> str:
+    Path(dest).mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_path) as zf:
+        zf.extractall(dest)
+    print(f">>> unzipped to {dest}", flush=True)
+    print(">>> contents:", flush=True)
+    for p in sorted(Path(dest).iterdir()):
+        size = p.stat().st_size
+        print(f"    {p.name:40s} {size:>12} bytes", flush=True)
+    return dest
+
+
+def sanity_check(model_dir: str) -> None:
+    print(f"\n>>> sanity check: load {model_dir} and generate", flush=True)
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+    import torch
+    m = AutoModelForCausalLM.from_pretrained(model_dir, dtype="auto", device_map="auto")
+    tok = AutoTokenizer.from_pretrained(model_dir)
+    inputs = tok.apply_chat_template(
+        [{"role": "user", "content": "Write a Python function that reverses a list."}],
+        return_tensors="pt", add_generation_prompt=True,
+    )
+    input_ids = inputs["input_ids"] if isinstance(inputs, dict) or hasattr(inputs, "data") else inputs
+    if not isinstance(input_ids, torch.Tensor):
+        input_ids = inputs.input_ids
+    input_ids = input_ids.to(m.device)
+    out_ids = m.generate(input_ids, max_new_tokens=200, do_sample=False)
+    print(tok.decode(out_ids[0][input_ids.shape[1]:], skip_special_tokens=True), flush=True)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--user_id",     required=True)
+    p.add_argument("--app_id",      required=True)
+    p.add_argument("--artifact_id", required=True)
+    p.add_argument("--version_id",  default="",
+                   help="Optional. If empty, the latest version of the artifact is used.")
+    p.add_argument("--workdir",     default="/tmp/artifact-roundtrip")
+    args = p.parse_args()
+
+    if not os.environ.get("CLARIFAI_PAT"):
+        raise SystemExit("CLARIFAI_PAT env var not set")
+
+    workdir = args.workdir
+    if Path(workdir).exists():
+        shutil.rmtree(workdir)
+    Path(workdir).mkdir(parents=True)
+
+    version_id = args.version_id or resolve_latest_version(args.user_id, args.app_id, args.artifact_id)
+    zip_path = download_artifact(args.user_id, args.app_id, args.artifact_id, version_id,
+                                 workdir)
+    model_dir = unzip(zip_path, str(Path(workdir) / "model"))
+    sanity_check(model_dir)
+    print("\n=== test_download_and_sanity.py done ===", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
  Add quantization example using llmcompressor. The quantization checkpoint                                                             
  will be uploaded as a Clarifai artifact. There is a download-test python
  script that you can launch afterwards to verify that the quantized model                                                              
  can be loaded successfully.                            
                                                                                                                                        
  This example shows how to take any HuggingFace transformers causal LM,                                                                
  run vLLM's llm-compressor on it inside a Clarifai pipeline step, and ship
  the resulting compressed-tensors checkpoint as a versioned Clarifai                                                                   
  artifact. A handful of input params let you pick the quantization scheme                                                              
  (W4A16, NVFP4, NVFP4A16, FP8, FP8_DYNAMIC, MXFP4, W8A8_INT8) and the                                                                  
  calibration pipeline (datafree, basic, sequential), so the same step                                                                  
  covers fast weight-only sanity runs and full W4A4 calibration on small                                                                
  MoE models.                                                                                                                           
                                                                                                                                        
  After the pipeline run completes, `test_download_and_sanity.py` pulls the                                                             
  artifact back from Clarifai, unzips it, loads the quantized weights with
  HF transformers, and runs a chat-template generation to confirm the                                                                   
  checkpoint round-trips end-to-end.                                                                                                    
                                                                                                                                        
  Defaults reproduce a 1-minute Qwen2.5-0.5B + W4A16 sanity; overrides for                                                              
  the MoE NVFP4 reference run (Granite-4-h-tiny) are documented in the
  help text and the README. See `README.md` for full launch / monitor /                                                                 
  download instructions.              