### PR TITLE
Fix LoRA pipeline dependencies

### DIFF
--- a/lora-pipeline-unsloth-quick-start/model-version-train-ps/requirements.txt
+++ b/lora-pipeline-unsloth-quick-start/model-version-train-ps/requirements.txt
@@ -8,7 +8,7 @@ datasets==3.6.0
 hf-transfer==0.1.9
 huggingface_hub==0.34.2
 peft==0.16.0
-transformers==5.0.0rc3
+transformers<5.0.0
 tokenizers==0.21.4
 trl==0.19.1
 unsloth==2025.7.8


### PR DESCRIPTION
## Why
* The LoRA unsloth pipeline fails to build due to a dependency version conflict betweeen transformers 5.0.0rc3 and tokenizers

## What
* Downgrades transformers to < 5.0.0 as least intrusive fix
* Attempts to upgrade led to cascading issues due to torch versions

## Test
* Verified `clarifai pipeline upload` and `clarifai pipeline run` complete as expected
